### PR TITLE
Disallow non multipart/form-data request payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Register the package as a server plugin to enable validation for each route that
 
 If the validation fails, a [joi](https://github.com/hapijs/joi)-like `400 Bad Request` error is returned alongside an additional `content-validation: failure` response header. If everything is ok, the response will ultimately contain a `content-validation: success` header.
 
+Also, if the `Content-Type` request header is not `multipart/form-data`, a `415 Unsupported Media Type` error is returned, but in this case, without any additional response header.
+
 ### Example
 
 ```js

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,14 +10,20 @@ internals.onPostAuth = function (options) {
 
     return function (request, reply) {
 
-        if (!(request.payload instanceof Buffer)) {
+        if (!Buffer.isBuffer(request.payload)) {
             return reply.continue();
         }
 
         const readable = Wreck.toReadableStream(request.payload);
         readable.headers = request.headers;
 
-        Subtext.parse(readable, null, { output: 'data', parse: true }, (err, parsed) => {
+        const config = {
+            allow: 'multipart/form-data',
+            output: 'data',
+            parse: true
+        };
+
+        Subtext.parse(readable, null, config, (err, parsed) => {
 
             if (err) {
                 return reply(err);

--- a/test/index.js
+++ b/test/index.js
@@ -81,7 +81,7 @@ lab.experiment('blaine', () => {
 
         streamToPromise(form).then((payload) => {
 
-            server.inject({ method: 'POST', payload: payload, url: '/main' }, (response) => {
+            server.inject({ headers: form.getHeaders(), method: 'POST', payload: payload, url: '/main' }, (response) => {
 
                 Code.expect(response.statusCode).to.equal(200);
                 Code.expect(response.headers['content-validation']).to.not.exist();
@@ -102,7 +102,7 @@ lab.experiment('blaine', () => {
 
             server.inject({ headers: { 'Content-Type': 'application/json' }, method: 'POST', payload: payload, url: '/main' }, (response) => {
 
-                Code.expect(response.statusCode).to.equal(400);
+                Code.expect(response.statusCode).to.equal(415);
                 Code.expect(response.headers['content-validation']).to.not.exist();
                 done();
             });


### PR DESCRIPTION
Resolves #7 but introduces a breaking change due to the internal validation performed by `Subtext`.